### PR TITLE
ci:  use cargo-make for CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install cargo-make
+      run: cargo install cargo-make
+
+    - name: Run cargo-make workflow (clean, build, test)
+      run: cargo make --verbose all

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,75 @@
+[config]
+default_to_workspace = false
+
+[tasks.ignore-members]
+workspace = false
+
+[tasks.clean]
+description = "Cleans the build directory."
+command = "cargo"
+args = ["clean"]
+
+[tasks.build]
+description = "Builds the Rust library and Python bindings."
+dependencies = ["build-rust", "build-python"]
+
+[tasks.clean-build]
+description = "Cleans the build directory and builds the Rust library and Python bindings."
+dependencies = ["clean", "build-rust", "build-python"]
+
+[tasks.test]
+description = "Tests the Rust library and Python bindings."
+dependencies = ["test-rust", "test-python"]
+
+[tasks.all]
+description = "Runs the default workflow."
+dependencies = [
+    "clean",
+    "build",
+    "test",
+]
+
+[tasks.rust-only]
+description = "Runs the default workflow for the Rust library only."
+dependencies = [
+    "clean",
+    "build-rust",
+    "test-rust",
+]
+
+[tasks.build-rust]
+description = "Builds the Rust library."
+command = "cargo"
+args = ["build", "--release"]
+
+[tasks.build-python]
+description = "Builds the Python bindings using Maturin."
+cwd = "python"
+install_crate = { crate_name = "maturin", binary = "maturin", test_arg = "--version" }
+command = "maturin"
+args = ["build", "--release"]
+
+[tasks.test-rust]
+description = "Tests the Rust library."
+command = "cargo"
+args = ["test"]
+
+[tasks.test-python]
+description = "Tests the Python bindings."
+dependencies = ["install-test-deps"]
+command = ".venv/bin/python"
+args = ["-m", "unittest", "python/tests/test_filter.py"]
+
+# Tasks for Python testing
+
+[tasks.create-venv]
+description = "Creates a Python virtual environment."
+command = "python"
+args = ["-m", "venv", ".venv"]
+
+[tasks.install-test-deps]
+description = "Installs Maturin and the local package with test dependencies in the Python virtual environment."
+dependencies = ["create-venv"]
+cwd = "python"
+command = "../.venv/bin/python"
+args = ["-m", "pip", "install", "maturin", ".[test]"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,3 +12,6 @@ authors = [
   { name = "Han-Sheng Wang", email = "hanson2693@gmail.com" },
 ]
 dynamic = ["version"]
+
+[project.optional-dependencies]
+test = ["numpy"]


### PR DESCRIPTION
Use cargo-make to automate the build process of the Rust crate and Python binding.